### PR TITLE
Introducing a new batch argument, support for 2019+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 p4-depot-renamer
+new_checkpoint
+.vscode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This code is provided as-is, with no warranty. The author(s) take no responsbili
 - This tool has only been tested against standard depots. **Graph, Stream, and Remote depots will likely not work!**
 - It has only been tested against a full checkpoint. **It may not work against journal data.**
 - It has only been tested against a depot with the standard mapping. If your depot's Map is not the default ie. `<depotname>/...`, you may wish to change it before proceeding.
-- It has not been tested against a Unicode server.
 
 ## Installation
 
@@ -45,7 +44,41 @@ Example usage:
 ```
 p4-depot-renamer -cp checkpoint.100 -depot mydepot -rename-to -mynewdepot -o checkpoint.100.renamed
 ```
+
 - `-cp <checkpoint file>` - Which checkpoint file to process.
 - `-depot <depot name>` - The name of the depot to be renamed.
 - `-rename-to <depot name>` - The new name of the depot.
 - `-o <new checkpoint file>` - The new checkpoint file to write.
+- `-f` - Forces overwriting the new checkpoint file if it already exists.
+- `-batch` - Batch mode - allows to batching multiple renames in one pass, also enables including/excluding certain transforms.
+
+## Advanced usage
+
+The batch argument allows to replace -depot/-rename-to with a YAML file that defines multiple transforms. Additionally, the batch argument allows
+specifying either an inclusion list (only transforms in the list are applied) or an exclusion list (transforms in the list are not applied).
+
+For example, the following YAML allows to move multiple depots under a single one:
+
+```
+- PathFrom: old_depot_first
+  PathTo: new_depot/first
+  ExcludedTransforms:
+    - db.depot:0
+    - db.depot:3
+    - db.domain:0
+- PathFrom: old_depot_second
+  PathTo: new_depot/second
+  ExcludedTransforms:
+    - db.depot:0
+    - db.depot:3
+    - db.domain:0
+```
+
+Note that in this case we want to exclude changes to domains/depots - we should instead manually create the new depots prior to the rename.
+
+
+## Running a demo example locally
+
+```
+go run . -batch demo_batch.yaml -cp demo_checkpoint -o new_checkpoint -f
+```

--- a/batch-args.go
+++ b/batch-args.go
@@ -1,0 +1,63 @@
+/**
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package main
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type BatchArgument struct {
+	PathFrom              string   `yaml:"path_from"`
+	PathTo                string   `yaml:"path_to"`
+	IncludedTransforms    []string `yaml:"included_transforms"`
+	ExcludedTransforms    []string `yaml:"excluded_transforms"`
+	IncludedTransformsMap map[string]bool
+	ExcludedTransformsMap map[string]bool
+}
+
+func BatchArguments(yamlPath string) ([]BatchArgument, error) {
+	content, err := ioutil.ReadFile(yamlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var batchArguments []BatchArgument
+	err = yaml.Unmarshal(content, &batchArguments)
+	// Convert exclusion/inclusion lists to maps for quick lookup
+	for index := range batchArguments {
+		batchArguments[index].IncludedTransformsMap = map[string]bool{}
+		batchArguments[index].ExcludedTransformsMap = map[string]bool{}
+		for _, includedTransform := range batchArguments[index].IncludedTransforms {
+			batchArguments[index].IncludedTransformsMap[includedTransform] = true
+		}
+		for _, excludedTransform := range batchArguments[index].ExcludedTransforms {
+			batchArguments[index].ExcludedTransformsMap[excludedTransform] = true
+		}
+	}
+
+	return batchArguments, err
+}

--- a/demo_batch.yaml
+++ b/demo_batch.yaml
@@ -1,0 +1,12 @@
+- path_from: old_depot_first
+  path_to: new_depot/first
+  excluded_transforms:
+    - db.depot:0
+    - db.depot:3
+    - db.domain:0
+- path_from: old_depot_second
+  path_to: new_depot/second
+  excluded_transforms:
+    - db.depot:0
+    - db.depot:3
+    - db.domain:0

--- a/demo_checkpoint
+++ b/demo_checkpoint
@@ -1,0 +1,277 @@
+@nx@ 0 1598328976 @49@ 10 0 0 0 0 @.@ @journal@ @@ @@ @@ 
+@nx@ 4 1598328976 @49@ 1 0 595927716 0 0 @db.config@ @@ @@ @@ @@ 
+@pv@ 1 @db.config@ @any@ @configurationVersion@ @1@ 
+@pv@ 1 @db.config@ @any@ @unicode@ @1@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 922921412 0 0 @db.configh@ @@ @@ @@ @@ 
+@pv@ 0 @db.configh@ @any@ @unicode@ 1 1598328709 @NoServerId@ @p4d-xi@ @unset@ @1@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 812011360 0 0 @db.counters@ @@ @@ @@ @@ 
+@pv@ 1 @db.counters@ @change@ @2@ 
+@pv@ 1 @db.counters@ @journal@ @2@ 
+@pv@ 1 @db.counters@ @lastCheckpointAction@ @1598328926 (2020/08/25 00:15:26 -0400 Eastern Daylight Time) checkpoint completed@ 
+@pv@ 1 @db.counters@ @maxCommitChange@ @2@ 
+@pv@ 1 @db.counters@ @upgrade@ @35@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.nameval@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.upgrades.rp@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 267802662 0 0 @db.upgrades@ @@ @@ @@ @@ 
+@pv@ 0 @db.upgrades@ 0 @SplitInteg@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 1 @SplitHave@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 2 @SplitChange@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 3 @TempObjRevUpdate@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 4 @TempObjWorkingUpdate@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 5 @IntializeDepotDepot@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 6 @ManglePasswords@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 7 @BuildHeadRev@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 8 @BuildLocks@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 9 @DeprecatedUpgradeStep@ 3 0 0 @@ 
+@pv@ 0 @db.upgrades@ 10 @BuildDelRev@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 11 @DeprecatedUpgradeStep@ 3 0 0 @@ 
+@pv@ 0 @db.upgrades@ 12 @MoveSpecDepot@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 13 @DeprecatedUpgradeStep@ 3 0 0 @@ 
+@pv@ 0 @db.upgrades@ 14 @DeprecatedUpgradeStep@ 3 0 0 @@ 
+@pv@ 0 @db.upgrades@ 15 @BuildHaveMaps@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 16 @DeprecatedUpgradeStep@ 3 0 0 @@ 
+@pv@ 0 @db.upgrades@ 17 @RemoveArchiveTable@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 18 @BuildCommonPath@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 19 @MoveBodyDate@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 20 @RemoveBodyDate@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 21 @AddConfig@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 22 @FixTiny@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 23 @MoveLdapSpecs@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 24 @SplitTemplate@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 25 @InitializeGraphDepot@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 26 @PerformUpgrade171@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 27 @PerformUpgrade172@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 28 @RemoveDbGraphIndex181@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 29 @IntializeExtsDepot182@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 30 @NormalizeTriggerFields182@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 31 @BuildStorage191@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 32 @AddDbTriggerExtNs@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 33 @MoveUpdateCachedRepos192@ 3 1598328666 1598328666 @@ 
+@pv@ 0 @db.upgrades@ 34 @CorrectConfigurableServerNames@ 3 1598328666 1598328666 @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.logger@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ldap@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 3 0 0 0 0 @db.server@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.svrview@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.remote@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.rmtview@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.stash@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 7 0 0 0 0 @db.user.rp@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 7 0 -211168555 0 0 @db.user@ @@ @@ @@ @@ 
+@pv@ 7 @db.user@ @davidair@ @davidair@@DAVIDAIR1-W@ @@ 1598328742 1598328742 @davidair@ @@ 0 @@ 0 0 0 0 0 0 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ticket.rp@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ticket@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.group@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.groupx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 215191142 0 0 @db.depot@ @@ @@ @@ @@ 
+@pv@ 1 @db.depot@ @.p4-extensions@ 8 @@ @.p4-extensions/...@ 
+@pv@ 1 @db.depot@ @depot@ 0 @@ @depot/...@ 
+@pv@ 1 @db.depot@ @new_depot@ 0 @@ @new_depot/...@ 
+@pv@ 1 @db.depot@ @old_depot_first@ 0 @@ @old_depot_first/...@ 
+@pv@ 1 @db.depot@ @old_depot_second@ 0 @@ @old_depot_second/...@ 
+@pv@ 1 @db.depot@ @repo@ 7 @@ @repo/...@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.stream@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 7 0 -1317046006 0 0 @db.domain@ @@ @@ @@ @@ 
+@pv@ 7 @db.domain@ @.p4-extensions@ 100 @@ @@ @@ @@ @@ 1598328666 1598328666 0 @Helix Core Extensions depot.@ @@ @@ 0 
+@pv@ 7 @db.domain@ @DAVIDAIR1-W@ 99 @DAVIDAIR1-W@ @d:\temp\renamer_demo\client@ @@ @@ @davidair@ 1598328807 1598328807 0 @Created by davidair.
+@ @@ @@ 1 
+@pv@ 7 @db.domain@ @depot@ 100 @@ @@ @@ @@ @@ 1598328666 1598328666 0 @Default depot@ @@ @@ 0 
+@pv@ 7 @db.domain@ @new_depot@ 100 @@ @@ @@ @@ @davidair@ 1598328967 1598328967 0 @Created by davidair.
+@ @@ @@ 0 
+@pv@ 7 @db.domain@ @old_depot_first@ 100 @@ @@ @@ @@ @davidair@ 1598328775 1598328775 0 @Created by davidair.
+@ @@ @@ 0 
+@pv@ 7 @db.domain@ @old_depot_second@ 100 @@ @@ @@ @@ @davidair@ 1598328784 1598328784 0 @Created by davidair.
+@ @@ @@ 0 
+@pv@ 7 @db.domain@ @repo@ 100 @@ @@ @@ @@ @@ 1598328666 1598328666 0 @Default graph depot@ @@ @@ 0 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 2 0 0 0 0 @db.template@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.templatesx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.templatewx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.view.rp@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 -1604223620 0 0 @db.view@ @@ @@ @@ @@ 
+@pv@ 1 @db.view@ @DAVIDAIR1-W@ 0 0 @//DAVIDAIR1-W/old_depot_second/...@ @//old_depot_second/...@ 
+@pv@ 1 @db.view@ @DAVIDAIR1-W@ 1 0 @//DAVIDAIR1-W/old_depot_first/...@ @//old_depot_first/...@ 
+@pv@ 1 @db.view@ @DAVIDAIR1-W@ 2 0 @//DAVIDAIR1-W/depot/...@ @//depot/...@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.repoview@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.haveview@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.review@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.integ@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.integed@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.integtx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.resolve@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.resolvex@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.resolveg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 3 0 0 0 0 @db.have.rp@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 3 0 1427259305 0 0 @db.have@ @@ @@ @@ @@ 
+@pv@ 3 @db.have@ @//DAVIDAIR1-W/old_depot_first/README.txt@ @//old_depot_first/README.txt@ 1 0 1598328849 
+@pv@ 3 @db.have@ @//DAVIDAIR1-W/old_depot_second/README.txt@ @//old_depot_second/README.txt@ 1 0 1598328894 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.label@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 2 0 0 0 0 @db.locks@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 2 0 0 0 0 @db.locksg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.excl@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.exclg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.exclgx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.archive@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.archmap@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.scandir@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.scanctl@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.storagesh@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 -1960363950 0 0 @db.storage@ @@ @@ @@ @@ 
+@pv@ 1 @db.storage@ @//old_depot_first/README.txt@ @1.1@ 0 1 3323B5ECD1E16158B522BBA4662415C2 18 212 00000000000000000000000000000000 1598328877 
+@pv@ 1 @db.storage@ @//old_depot_second/README.txt@ @1.2@ 0 1 98BED0752A0C935079795120C57A22FF 19 213 00000000000000000000000000000000 1598328911 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.storageg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 1836884272 0 0 @db.rev@ @@ @@ @@ @@ 
+@pv@ 9 @db.rev@ @//old_depot_first/README.txt@ 1 0 0 1 1598328877 1598328849 3323B5ECD1E16158B522BBA4662415C2 18 0 0 @//old_depot_first/README.txt@ @1.1@ 0 
+@pv@ 9 @db.rev@ @//old_depot_second/README.txt@ 1 0 0 2 1598328911 1598328894 98BED0752A0C935079795120C57A22FF 19 0 0 @//old_depot_second/README.txt@ @1.2@ 0 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revtx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 1315408074 0 0 @db.revcx@ @@ @@ @@ @@ 
+@pv@ 0 @db.revcx@ 2 @//old_depot_second/README.txt@ 1 0 
+@pv@ 0 @db.revcx@ 1 @//old_depot_first/README.txt@ 1 0 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revdx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 1018325449 0 0 @db.revhx@ @@ @@ @@ @@ 
+@pv@ 9 @db.revhx@ @//old_depot_first/README.txt@ 1 0 0 1 1598328877 1598328849 3323B5ECD1E16158B522BBA4662415C2 18 0 0 @//old_depot_first/README.txt@ @1.1@ 0 
+@pv@ 9 @db.revhx@ @//old_depot_second/README.txt@ 1 0 0 2 1598328911 1598328894 98BED0752A0C935079795120C57A22FF 19 0 0 @//old_depot_second/README.txt@ @1.2@ 0 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revsx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revsh@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revbx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revux@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 9 0 0 0 0 @db.revstg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 10 0 0 0 0 @db.working@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 10 0 0 0 0 @db.workingx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.workingg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.haveg@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.traits@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 3 0 0 0 0 @db.trigger@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 6 0 -693255498 0 0 @db.change@ @@ @@ @@ @@ 
+@pv@ 6 @db.change@ 2 2 @DAVIDAIR1-W@ @davidair@ 1598328911 1 @Second depot@ @//old_depot_second/*@ @@ @@ 0 0 @@ 
+@pv@ 6 @db.change@ 1 1 @DAVIDAIR1-W@ @davidair@ 1598328877 1 @First depot@ @//old_depot_first/*@ @@ @@ 0 0 @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 6 0 0 0 0 @db.changex@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.changeidx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 -425588138 0 0 @db.desc@ @@ @@ @@ @@ 
+@pv@ 0 @db.desc@ 2 @Second depot@ 
+@pv@ 0 @db.desc@ 1 @First depot@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 3 0 0 0 0 @db.repo@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.refhist@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ref@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.object@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.graphindex@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.graphperm@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.submodule@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.pubkey@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.job@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.jobpend@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.jobdesc@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.fix@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.fixrev@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.boddate@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.bodresolve@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 1 0 0 0 0 @db.bodtext@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.bodtextcx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.bodtexthx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.bodtextsx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.bodtextwx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ixdate@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ixtext@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.ixtexthx@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.uxtext@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 5 0 0 0 0 @db.protect@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.property@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 4 1598328976 @49@ 0 0 0 0 0 @db.message@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976
+@nx@ 1 1598328976 @49@ 0 0 0 0 0 @@ @@ @@ @@ @@ 
+@ex@ 24960 1598328976

--- a/p4-depot-renamer.go
+++ b/p4-depot-renamer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 var (
@@ -13,6 +14,8 @@ var (
 	depotTo                  = flag.String("rename-to", "", "New name of the depot")
 	checkpointFileName       = flag.String("cp", "", "Checkpoint file to process")
 	checkpointOutputFileName = flag.String("o", "checkpoint.renamed", "Checkpoint file to write out")
+	batchArgumentsFileName   = flag.String("batch", "", "Path to the batch arguments - use instead of depot/rename-to")
+	forceOverwrite           = flag.Bool("f", false, "Overwrites the target file if exists")
 )
 
 func endOfFile(c chan<- JournalLine) {
@@ -58,11 +61,28 @@ func lineWriter(c <-chan JournalLine) {
 
 func main() {
 	flag.Parse()
-	if *depotFrom == "" {
+
+	var batchArguments []BatchArgument
+	var err error
+
+	if *batchArgumentsFileName != "" {
+		if *depotFrom != "" || *depotTo != "" {
+			log.Fatalf("please do not specify -depot or -rename-to if -batch is specified")
+			return
+		}
+
+		batchArguments, err = BatchArguments(*batchArgumentsFileName)
+		if err != nil {
+			log.Fatalf("error reading batch arguments: %v", err)
+			return
+		}
+	}
+
+	if *depotFrom == "" && len(batchArguments) == 0 {
 		log.Fatalf("-depot not specified")
 		return
 	}
-	if *depotTo == "" {
+	if *depotTo == "" && len(batchArguments) == 0 {
 		log.Fatalf("-rename-to not specified")
 		return
 	}
@@ -74,17 +94,32 @@ func main() {
 		log.Fatalf("-o not specified")
 		return
 	}
-	if _, err := os.Stat(*checkpointOutputFileName); !os.IsNotExist(err) {
-		log.Fatalf("%s already exists, cannot overwrite", *checkpointOutputFileName)
+	if strings.EqualFold(*checkpointFileName, *checkpointOutputFileName) {
+		log.Fatalf("files specified by -cp and -o cannot be the same")
 		return
 	}
 
+	if _, err := os.Stat(*checkpointOutputFileName); !os.IsNotExist(err) {
+		if !(*forceOverwrite) {
+			log.Fatalf("%s already exists, cannot overwrite", *checkpointOutputFileName)
+			return
+		}
+	}
+
+	if len(batchArguments) == 0 {
+		batchArguments = append(batchArguments, BatchArgument{
+			PathFrom:           *depotFrom,
+			PathTo:             *depotTo,
+			IncludedTransforms: []string{},
+			ExcludedTransforms: []string{},
+		})
+	}
+
 	log.Printf("will read and transform %s", *checkpointFileName)
-	log.Printf("renaming depot \"%s\" to \"%s\"...", *depotFrom, *depotTo)
 	readerOut := make(chan JournalLine)
 	transOut := make(chan JournalLine)
 	go readCheckpoint(readerOut)
-	go transformer(readerOut, transOut, *depotFrom, *depotTo)
+	go transformer(readerOut, transOut, batchArguments)
 	lineWriter(transOut)
 
 	log.Printf("transforms have been applied and saved to %s, you can now use it to restore your database", *checkpointOutputFileName)


### PR DESCRIPTION
- Introducing support for a new optional "batch" argument that allows doing multiple renames in one pass (especially useful for large checkpoints) and allows using an inclusion/exclusion mechanism for filtering transforms

- Introducing an optional "-f" flag to allow overwriting the new checkpoint

- Introducing the db.storage table (required for 2019 and newer versions)

- Tested on unicode